### PR TITLE
TFM-29 | Apply terraform with actions

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,55 @@
+name: "Terraform Apply"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  terraform:
+    name: "Terraform Apply"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: Get Token From GitHub APP
+        id: get_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.UNIR_TFM_APP_ID }}
+          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: "Build Azure credentials JSON"
+        id: build_creds
+        run: |
+          CREDS_JSON=$(jq -n --arg clientSecret "$AZURE_CLIENT_SECRET" \
+                              --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
+                              --arg tenantId "$AZURE_TENANT_ID" \
+                              --arg clientId "$AZURE_CLIENT_ID" \
+          '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
+          echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
+        env:
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: "Configure Azure credentials"
+        uses: azure/login@v2
+        with:
+          creds: ${{ steps.build_creds.outputs.creds }}
+
+      - name: "Setup Terraform"
+        uses: hashicorp/setup-terraform@v3
+
+      - name: "Terraform Format Check"
+        run: terraform fmt -check
+
+      - name: "Terraform Init"
+        run: terraform init -input=false
+
+      - name: "Terraform Plan"
+        run: terraform plan -input=false
+
+      - name: "Terraform Apply"
+        run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -22,10 +22,10 @@ jobs:
       - name: "Build Azure credentials JSON"
         id: build_creds
         run: |
-          CREDS_JSON=$(jq -n --arg clientSecret "$AZURE_CLIENT_SECRET" \
-                              --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
-                              --arg tenantId "$AZURE_TENANT_ID" \
-                              --arg clientId "$AZURE_CLIENT_ID" \
+          CREDS_JSON=$(jq -nc --arg clientSecret "$AZURE_CLIENT_SECRET" \
+                            --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
+                            --arg tenantId "$AZURE_TENANT_ID" \
+                            --arg clientId "$AZURE_CLIENT_ID" \
           '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
           echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -1,0 +1,44 @@
+name: "Terraform Destroy"
+
+on:
+  schedule:
+    - cron: "0 21 * * *" # Every day at 21:00 UTC
+  workflow_dispatch:
+
+jobs:
+  destroy:
+    name: "Terraform Destroy"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Build Azure credentials JSON"
+        id: build_creds
+        run: |
+          CREDS_JSON=$(jq -n --arg clientSecret "$AZURE_CLIENT_SECRET" \
+                              --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
+                              --arg tenantId "$AZURE_TENANT_ID" \
+                              --arg clientId "$AZURE_CLIENT_ID" \
+          '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
+          echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
+        env:
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: "Configure Azure credentials"
+        uses: azure/login@v2
+        with:
+          creds: ${{ steps.build_creds.outputs.creds }}
+
+      - name: "Setup Terraform"
+        uses: hashicorp/setup-terraform@v3
+
+      - name: "Terraform Init"
+        run: terraform init -input=false
+
+      - name: "Terraform Destroy"
+        run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -17,10 +17,10 @@ jobs:
       - name: "Build Azure credentials JSON"
         id: build_creds
         run: |
-          CREDS_JSON=$(jq -n --arg clientSecret "$AZURE_CLIENT_SECRET" \
-                              --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
-                              --arg tenantId "$AZURE_TENANT_ID" \
-                              --arg clientId "$AZURE_CLIENT_ID" \
+          CREDS_JSON=$(jq -nc --arg clientSecret "$AZURE_CLIENT_SECRET" \
+                           --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
+                           --arg tenantId "$AZURE_TENANT_ID" \
+                           --arg clientId "$AZURE_CLIENT_ID" \
           '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
           echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -25,10 +25,10 @@ jobs:
       - name: "Build Azure credentials JSON"
         id: build_creds
         run: |
-          CREDS_JSON=$(jq -n --arg clientSecret "$AZURE_CLIENT_SECRET" \
-                              --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
-                              --arg tenantId "$AZURE_TENANT_ID" \
-                              --arg clientId "$AZURE_CLIENT_ID" \
+          CREDS_JSON=$(jq -nc --arg clientSecret "$AZURE_CLIENT_SECRET" \
+                           --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
+                           --arg tenantId "$AZURE_TENANT_ID" \
+                           --arg clientId "$AZURE_CLIENT_ID" \
           '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
           echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,62 @@
+name: "Terraform Plan"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  terraform:
+    name: "Terraform Plan"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: Get Token From GitHub APP
+        id: get_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.UNIR_TFM_APP_ID }}
+          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: "Build Azure credentials JSON"
+        id: build_creds
+        run: |
+          CREDS_JSON=$(jq -n --arg clientSecret "$AZURE_CLIENT_SECRET" \
+                              --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
+                              --arg tenantId "$AZURE_TENANT_ID" \
+                              --arg clientId "$AZURE_CLIENT_ID" \
+          '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
+          echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
+        env:
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: "Configure Azure credentials"
+        uses: azure/login@v2
+        with:
+          creds: ${{ steps.build_creds.outputs.creds }}
+
+      - name: "Setup Terraform"
+        uses: hashicorp/setup-terraform@v3
+
+      - name: "Terraform Format Check"
+        run: terraform fmt -check
+
+      - name: "Terraform Init"
+        run: terraform init -input=false
+
+      - name: "Terraform Plan"
+        run: terraform plan -out .planfile -input=false
+
+      - name: Post PR comment
+        if: always()
+        uses: borchero/terraform-plan-comment@v2
+        with:
+          token: ${{ steps.get_token.outputs.token }}
+          planfile: .planfile

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,9 @@ module "aks" {
   location            = "East US"
 
   kubernetes_version = "1.32"
-  prefix = "unir-tfm"
+  prefix             = "unir-tfm"
 
-  agents_size = "Standard_B2s"
+  agents_size  = "Standard_B2s"
   agents_count = 2
 
   node_pools = {
@@ -17,12 +17,12 @@ module "aks" {
       name       = "default"
       vm_size    = "Standard_B2s"
       node_count = 2
-      mode = "User"
+      mode       = "User"
     }
   }
 
-  identity_type = "SystemAssigned"
-  rbac_aad = false
+  identity_type                     = "SystemAssigned"
+  rbac_aad                          = false
   role_based_access_control_enabled = false
-  log_analytics_workspace_enabled = false
+  log_analytics_workspace_enabled   = false
 }


### PR DESCRIPTION
This pull request introduces three new GitHub Actions workflows to automate Terraform operations: `terraform-apply`, `terraform-destroy`, and `terraform-plan`. These workflows streamline infrastructure management by integrating Terraform with Azure and GitHub.

### New Terraform Workflows

* **Terraform Apply Workflow**:
  - Adds a `workflow_dispatch`-triggered workflow for applying Terraform changes. 
  - Includes steps for Azure authentication, Terraform setup, and running `terraform apply`. (`.github/workflows/terraform-apply.yml`, [.github/workflows/terraform-apply.ymlR1-R55](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eR1-R55))

* **Terraform Destroy Workflow**:
  - Adds a scheduled and manually triggered workflow for destroying Terraform-managed infrastructure.
  - Configures Azure credentials and runs `terraform destroy`. (`.github/workflows/terraform-destroy.yml`, [.github/workflows/terraform-destroy.ymlR1-R44](diffhunk://#diff-9dff5fac2f6cd80e8a50601fc837a18f6f01c7d944821025562e97e3d9e74d25R1-R44))

* **Terraform Plan Workflow**:
  - Adds a pull-request-triggered workflow for generating and commenting on Terraform plans.
  - Posts the plan output as a comment on the pull request for review. (`.github/workflows/terraform-plan.yml`, [.github/workflows/terraform-plan.ymlR1-R62](diffhunk://#diff-1ca63e6aac27d170492851d93ed42746d3493ce0db3c6ee7422efa4b7e3f0b6dR1-R62))